### PR TITLE
fix(migration_tool): do not create a page when an internal url is redirected to an external

### DIFF
--- a/packages/bodiless-migration-tool/src/page-creator.ts
+++ b/packages/bodiless-migration-tool/src/page-creator.ts
@@ -23,6 +23,7 @@ import {
   ensureDirectoryExistence,
   isUrlExternal,
   mapUrlToFilePath,
+  trimQueryParamsFromUrl,
 } from './helpers';
 import Downloader from './downloader';
 import {
@@ -86,6 +87,7 @@ export class PageCreator {
       return '';
     }
     filePath = this.removeExtension(filePath);
+    filePath = trimQueryParamsFromUrl(filePath);
     return filePath === '/' ? fileName : (`${filePath}/${fileName}`);
   }
 

--- a/packages/bodiless-migration-tool/src/scraper.ts
+++ b/packages/bodiless-migration-tool/src/scraper.ts
@@ -18,7 +18,10 @@ import url from 'url';
 import { Request } from '@bodiless/headless-chrome-crawler/lib/puppeteer';
 // @ts-ignore - ignoring as it contains functions that invoked in browser
 import evaluatePage from './evaluate-page';
-import { trimQueryParamsFromUrl } from './helpers';
+import {
+  isUrlExternal,
+  trimQueryParamsFromUrl,
+} from './helpers';
 import debug from './debug';
 // require due to ES6 modules cannot directly export class objects.
 import HCCrawler = require('@bodiless/headless-chrome-crawler');
@@ -89,6 +92,11 @@ export class Scraper extends EE<Events> {
       onSuccess: (async successResult => {
         try {
           const { result } = successResult;
+          // we can get an external url here
+          // when an internal url is redirected to the external
+          if (isUrlExternal(this.params.pageUrl, successResult.response.url)) {
+            return;
+          }
           result.pageUrl = successResult.response.url;
           // @ts-ignore
           result.rawHtml = await successResult.rawHtml;


### PR DESCRIPTION

<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/master/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
* fix(migration_tool): do not create a page when an internal url is redirected to an external

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
